### PR TITLE
Zorin setup.sh for gaming.

### DIFF
--- a/linux/zorin/setup.sh
+++ b/linux/zorin/setup.sh
@@ -4,9 +4,30 @@ echo "Removing Brave Browser..."
 sudo apt autoremove -y --purge brave-browser
 
 echo "Installing software..."
-flatpak install -y flathub com.google.Chrome
-flatpak install -y flathub org.mozilla.firefox
 flatpak install -y flathub org.videolan.VLC
+flatpak install -y flathub com.discordapp.Discord
+flatpak install -y flathub com.valvesoftware.Steam
+
+# Choose browser, set as default browser and PDF Viewer
+while [ -z "$browser" ]; do
+  read -n 1 -r -p "Would you prefer Mozilla Firefox or Google Chrome as your default browser and PDF viewer? Press 1 for Firefox, or 2 for Chrome." answer
+  case "$answer" in
+    1) browser="firefox" ;;
+    2) browser="chrome" ;;
+    *) echo "Please only press 1 or 2." ;;
+  esac
+done
+
+if [[ "$browser" == "firefox" ]]; then
+    flatpak install -y flathub org.mozilla.firefox
+    xdg-settings set default-web-browser org.mozilla.firefox.desktop
+    xdg-mime default org.mozilla.firefox.desktop application/pdf
+else
+    flatpak install -y flathub com.google.Chrome
+    xdg-settings set default-web-browser com.google.Chrome.desktop
+    xdg-mime default com.google.Chrome.desktop application/pdf
+fi
+
 
 # Apply configurations
 echo "Configuring Libre Office..."
@@ -24,11 +45,6 @@ xdg-mime default org.videolan.VLC.desktop audio/mpeg
 xdg-mime default org.videolan.VLC.desktop audio/x-wav
 xdg-mime default org.videolan.VLC.desktop audio/mp4
 xdg-mime default org.videolan.VLC.desktop application/ogg
-
-# Set firefox as default PDF & Browser
-echo "setting default browser..."
-xdg-settings set default-web-browser org.mozilla.firefox.desktop
-xdg-mime default org.mozilla.firefox.desktop application/pdf
 
 echo "Configuring GNOME..."
 # Set power settings to keep screen on


### PR DESCRIPTION
Added Steam and Discord. Could add FurMark as a benchmark/stress test, if we want this to be part of the shipped package. Otherwise, it should be considered for the stress rig. `flatpak install -y flathub com.geeks3d.furmark` would be added below line 9 to accommodate this. 

Added browser choice option to remove the need to install both browsers, unless there was a reason in the background that I'm not aware of. Please give it a review and a test. Since the user is choosing the browser, I did no see a reason to keep the prompt saying that we're setting the default browser; if we're letting them make the choice, I feel it is expected that it would be set as default.